### PR TITLE
Support pshell scripts

### DIFF
--- a/pyramid_deferred_sqla/__init__.py
+++ b/pyramid_deferred_sqla/__init__.py
@@ -161,7 +161,7 @@ def _create_session(request):
 
     # Now that we have a connection, we're going to go and set it to the
     # correct isolation level.
-    if request.read_only:
+    if getattr(request, 'read_only', None):
         session.connection(execution_options={'isolation_level': 'SERIALIZABLE READ ONLY DEFERRABLE'})
 
     # Register only this particular session with zope.sqlalchemy


### PR DESCRIPTION
When using pshell scripts that bootstrap the pyramid environment with a
fake request, the request does not go through the view mechanism and as
such does not get the `read_only` attribute assigned.

This commit add support for doing the following in a pshell script:

```python
from pyramid.paster import bootstrap
env = bootstrap(parser.parse_args().config)
env["request"].db
```