### PR TITLE
Refactor SKIP_CHECK_DB_MIGRATED into pyramid_deferred_sqla.check_db_migrated

### DIFF
--- a/pyramid_deferred_sqla/__init__.py
+++ b/pyramid_deferred_sqla/__init__.py
@@ -230,8 +230,10 @@ def check_db_migrated(config: Configurator) -> None:
     the filesystem.
     """
 
-    # skip if SKIP_CHECK_DB_MIGRATED is set
-    if config.registry.settings.get("SKIP_CHECK_DB_MIGRATED"):
+    # skip if "pyramid_deferred_sqla.check_db_migrated = false" in INI file
+    if not config.registry.settings.get(
+        "pyramid_deferred_sqla.check_db_migrated", True
+    ):
         return
 
     # skip if we are bootstrapping from alembic env, meaning when running
@@ -254,7 +256,7 @@ def check_db_migrated(config: Configurator) -> None:
             "ERROR: The latest Alembic migration applied to the DB is "
             f"{curr}, but I found a more recent migration on the filesystem: "
             f"{head}. Please upgrade your DB to Alembic 'head' or skip this "
-            "check by setting SKIP_CHECK_DB_MIGRATED=1."
+            "check by setting pyramid_deferred_sqla.check_db_migrated=0."
         )
 
 

--- a/tests/test_check_db_migrated.py
+++ b/tests/test_check_db_migrated.py
@@ -9,10 +9,10 @@ import pytest
 import urllib
 
 
-def test_SKIP_CHECK_DB_MIGRATED() -> None:
+def test_skipping_migrated_check() -> None:
     """Support skipping the check with a config flag."""
     config = Configurator()
-    config.registry.settings["SKIP_CHECK_DB_MIGRATED"] = "true"
+    config.registry.settings["pyramid_deferred_sqla.check_db_migrated"] = False
 
     assert check_db_migrated(config) is None
 
@@ -62,7 +62,7 @@ def test_database_outdated(
     sys.exit.assert_called_with(
         "ERROR: The latest Alembic migration applied to the DB is bar, but I "
         "found a more recent migration on the filesystem: foo. Please upgrade "
-        "your DB to Alembic 'head' or skip this check by setting SKIP_CHECK_DB_MIGRATED=1."
+        "your DB to Alembic 'head' or skip this check by setting pyramid_deferred_sqla.check_db_migrated=0."
     )
 
 


### PR DESCRIPTION
It's unfortunate that most of our packages expose configuration with flags named like `<package_name>.<flag>`, but this packages uses screaming instead. Let's be nicer. 